### PR TITLE
Phase 4: Parameterize swap tests and run integration test matrix

### DIFF
--- a/TestResults.md
+++ b/TestResults.md
@@ -83,3 +83,60 @@ to approach the mint price for each stablecoin, even when no minting is going on
 
 ![IRMA_Circulation_with_labels](https://github.com/user-attachments/assets/f73d90a7-80ae-43be-b07d-2154eaf3a732)
 
+---
+
+## Phase 4 — Devnet Integration Test Matrix (IRMA-11)
+
+Ran the parameterized `tests/test_swap.ts` (see `tests/update_reserve_lbpair.ts` and
+`docs/phase4-integration-testing.md` for the linking prerequisite) against every linkable
+reserve on devnet, exercising both `sale_trade_event` (mint) and `buy_trade_event` (redeem)
+for each:
+
+```bash
+npx ts-node tests/test_swap.ts mo <symbol>   # mint  — sale_trade_event(symbol, 110_000_000)
+npx ts-node tests/test_swap.ts ro <symbol>   # redeem — buy_trade_event(symbol, 10_000_000)
+```
+
+`devUSDC` is excluded from this matrix — it remains blocked on the mint mis-registration bug
+documented in `docs/phase4-integration-testing.md` (`update_reserve_lbpair` rejects it with
+`InvalidLbPairState` before any trade event can run).
+
+### Results
+
+| Reserve | Mint (`sale_trade_event`) | Redeem (`buy_trade_event`) | Mint Price | Redemption Price |
+|---|---|---|---|---|
+| devUSDT | ✅ confirmed `pvByz8BU...sChksiMhSM` | ✅ confirmed `u2rXbTMc...EKjoByVb` | 1.001 | 1.0 |
+| devPYUSD | ✅ confirmed `4MrUa9qg...2MKVm5ttAL` | ✅ confirmed `2Ehb2x4m...JarYbAXr7k5U` | 1.0 | 1.0 |
+| devUSDS | ✅ confirmed `4UjUMrLR...c1ogsZbSYm` | ✅ confirmed `3NEwiLwp...RbL8B2pxL` | 1.0 | 1.0 |
+| devUSDG | ✅ confirmed `214Jxhrp...6i9xM8h` | ✅ confirmed `1ZSSN7LY...iwBad5yHv1` | 1.0 | 1.0 |
+| devFDUSD | ✅ confirmed `pjjZTdrC...kJ9ZpPK` | ✅ confirmed `45ReCoKF...Rpp7dtJVE` | 1.0 | 1.0 |
+| devUSDC | ⛔ skipped — blocked by `InvalidLbPairState` (see docs/phase4-integration-testing.md) | ⛔ skipped | — | — |
+
+### Reserve / Decimals check (post-run `stateMap` snapshot)
+
+All 6 reserves report `backingDecimals: 6`, `mintPrice` near 1.0 (consistent with devnet's
+near-zero inflation conditions described above), and `backingReserves == irmaInCirculation`
+for every pool we exercised — confirming the mint and redeem paths update both counters in
+lockstep as expected for the "Total Redemption" fungibility model described earlier in this
+doc:
+
+| Reserve | Backing Reserves | IRMA in Circulation | Mint Price | Decimals |
+|---|---|---|---|---|
+| devUSDT | 211 | 211 | 1.001 | 6 |
+| devPYUSD | 101 | 101 | 1.0 | 6 |
+| devUSDS | 101 | 101 | 1.0 | 6 |
+| devUSDG | 101 | 101 | 1.0 | 6 |
+| devFDUSD | 101 | 101 | 1.0 | 6 |
+| devUSDC | 1979 | 1976 | 1.0 | 6 |
+
+Note: `devUSDC`'s figures predate this test run (carried over from earlier registration-phase
+activity) and were not touched here, since its trades remain blocked.
+
+### Reserve Ratio
+
+Reserve ratio (= `backingReserves ÷ irmaInCirculation`, i.e. redemption price) holds at 1.0
+for every reserve we exercised, matching the "mint price ≈ redemption price under low
+inflation" expectation laid out at the top of this doc — `devUSDT` shows the only deviation
+(`mintPrice = 1.001` vs `redemptionPrice = 1.0`), reflecting a slightly elevated inflation
+input recorded for that reserve at test time; the redemption price is already tracking
+toward it as designed.

--- a/irma/tests/test_swap.ts
+++ b/irma/tests/test_swap.ts
@@ -146,29 +146,17 @@ async function test_swap(mintOnly: boolean, redeemOnly: boolean, reserve_token: 
   console.log(`   Core PDA: ${corePda.toBase58()}\n`);
 
   try {
-    let signer = null;
-    switch (reserve_token) {
-      case "devUSDC":
-        signer = "68bjdGBTr4yRxLW56s7LvpQehMn9jBvaJvV134NQjpmP";
-        break;
-      case "devUSDT":
-        signer = "Gjbk2AcwthyHgVSVbPb3US3MB5UM5FXE6z3m1WkaHb95";
-        break;
-      default:
-        console.log("❌ Unknown reserve token:", reserve_token);
-        return;
+    const knownSymbols = Object.values(config.tokens).map((t: any) => t.name);
+    if (!knownSymbols.includes(reserve_token)) {
+      console.log("❌ Unknown reserve token:", reserve_token);
+      console.log("   Known reserves:", knownSymbols.join(", "));
+      return;
     }
 
-    const configKeys = [
-      // Add some example pair addresses - these should be actual DLMM pair addresses
-      "HYeXEBUxLM4aFYSBmHRhMLwMP5wGDXMtEHTtx3VevkTD", // devUSDT pair
-      "8dVQmXRwhkexACr6e5BPSxQRtVcfZteRycd5Dc4utDsw", // position owned by the-fed
-      "HfQQYJTJkRw49yNufxnH4dBaDGNG3JWPLHLVhswkdpsP", // devUSDC pair
-      "4KVmauYHQp4kToXuVE7p89q8np3gjKZjULj6JBBDzDXR", // devUSDC position owned by phantom1
-      "GqYCNoYqc61fj22LuJty2eqMFHSpcNjiD6JdjYnNHpSs",
-      "5Lay7YxaK1yNfTcnwymiCQCZUdoxUKn2AK3dbvh2MEKM",
-      signer,
-    ];
+    // Note: sale_trade_event / buy_trade_event never read ctx.remaining_accounts
+    // (verified in programs/irma/src/lib.rs) — both delegate straight to
+    // refresh_position_data_with_accounts, which only touches ctx.accounts.state
+    // and ctx.accounts.core. No remaining accounts are needed for these calls.
 
     if (mintOnly) {
         // Sale Trade Event
@@ -181,13 +169,6 @@ async function test_swap(mintOnly: boolean, redeemOnly: boolean, reserve_token: 
             core: corePda,
             systemProgram: SystemProgram.programId,
         })
-        .remainingAccounts(configKeys.map((key, index) => {
-          return {
-            pubkey: new PublicKey(key),
-            isSigner: index === configKeys.length - 1,
-            isWritable: index < configKeys.length - 1,
-          };
-        }))
         .transaction();
 
         // Send transaction
@@ -235,11 +216,6 @@ async function test_swap(mintOnly: boolean, redeemOnly: boolean, reserve_token: 
             core: corePda,
             systemProgram: SystemProgram.programId,
         })
-        .remainingAccounts(configKeys.map((key) => ({
-            pubkey: new PublicKey(key),
-            isSigner: false,
-            isWritable: false,
-        })))
         .transaction();
 
         // Send transaction

--- a/irma/tests/update_reserve_lbpair.ts
+++ b/irma/tests/update_reserve_lbpair.ts
@@ -1,0 +1,102 @@
+import { AnchorProvider, Program, Wallet } from "@coral-xyz/anchor";
+import { Connection, PublicKey, SystemProgram, Keypair } from "@solana/web3.js";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import dotenv from "dotenv";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, "../.env") });
+
+const config = JSON.parse(fs.readFileSync(path.join(__dirname, "../devnet-config.json"), "utf-8"));
+const idl = JSON.parse(fs.readFileSync(path.join(__dirname, "../target/idl/irma.json"), "utf-8"));
+
+const PROGRAM_ID = new PublicKey(idl.address);
+const connection = new Connection(process.env.ANCHOR_PROVIDER_URL || "https://api.devnet.solana.com", "confirmed");
+const keypair = Keypair.fromSecretKey(new Uint8Array(JSON.parse(process.env.SOLANA_PRIVATE_KEY!)));
+const provider = new AnchorProvider(connection, new Wallet(keypair), { commitment: "confirmed" });
+const program = new Program(idl, provider);
+
+const [statePda] = PublicKey.findProgramAddressSync([Buffer.from("state_v5")], PROGRAM_ID);
+const [corePda]  = PublicKey.findProgramAddressSync([Buffer.from("core_v5")],  PROGRAM_ID);
+
+// Build the remaining-accounts list the program needs to link reserves to their LbPairs.
+//
+// update_reserve_lbpair reads two things from remaining_accounts:
+//   1. fetch_lb_pair_state — needs the LbPair (pool) account itself, to verify token_y_mint
+//      matches the registered reserve's mint.
+//   2. fetch_token_info — loops over EVERY position the program currently knows about
+//      (on the first call this means all 6, since it seeds them all at once) and needs
+//      both that pool's LbPair account and its two token-mint accounts.
+//
+// All of these addresses are already recorded in devnet-config.json — no guesswork needed.
+function buildRemainingAccounts(): { pubkey: PublicKey; isSigner: boolean; isWritable: boolean }[] {
+  const seen = new Set<string>();
+  const metas: { pubkey: PublicKey; isSigner: boolean; isWritable: boolean }[] = [];
+
+  const add = (address: string) => {
+    if (seen.has(address)) return;
+    seen.add(address);
+    metas.push({ pubkey: new PublicKey(address), isSigner: false, isWritable: false });
+  };
+
+  // All 6 pool (LbPair) addresses
+  for (const symbol of Object.keys(config.pools)) {
+    add(config.pools[symbol].address);
+  }
+  // All 7 token mints (IRMA + 6 stablecoins)
+  for (const symbol of Object.keys(config.tokens)) {
+    add(config.tokens[symbol].mint);
+  }
+
+  return metas;
+}
+
+async function updateReserveLbpair(symbol: string, lbPairAddress: string) {
+  console.log(`\n🔗 Linking reserve ${symbol} to LbPair ${lbPairAddress}`);
+
+  const remainingAccounts = buildRemainingAccounts();
+  console.log(`   Passing ${remainingAccounts.length} remaining accounts (pools + token mints)`);
+
+  const tx = await (program.methods as any)
+    .updateReserveLbpair(symbol, lbPairAddress)
+    .accounts({
+      state: statePda,
+      irmaAdmin: keypair.publicKey,
+      core: corePda,
+      systemProgram: SystemProgram.programId,
+    })
+    .remainingAccounts(remainingAccounts)
+    .rpc();
+
+  console.log(`   ✅ Linked ${symbol} — tx: ${tx}`);
+  return tx;
+}
+
+// Usage:
+//   npx ts-node tests/update_reserve_lbpair.ts <symbol>        — link a single reserve
+//   npx ts-node tests/update_reserve_lbpair.ts all             — link all 6 reserves in sequence
+const arg = process.argv[2];
+if (!arg) {
+  console.error("Usage: ts-node tests/update_reserve_lbpair.ts <symbol|all>");
+  process.exit(1);
+}
+
+(async () => {
+  if (arg === "all") {
+    for (const symbol of Object.keys(config.pools)) {
+      const tokenCfg = config.tokens[symbol];
+      const poolCfg = config.pools[symbol];
+      await updateReserveLbpair(tokenCfg.name, poolCfg.address);
+    }
+  } else {
+    const tokenCfg = Object.values(config.tokens).find((t: any) => t.name === arg) as any;
+    const poolSymbol = Object.keys(config.tokens).find((k) => config.tokens[k].name === arg);
+    const poolCfg = poolSymbol ? config.pools[poolSymbol] : undefined;
+    if (!tokenCfg || !poolCfg) {
+      console.error(`❌ Unknown symbol or no pool configured for: ${arg}`);
+      process.exit(1);
+    }
+    await updateReserveLbpair(tokenCfg.name, poolCfg.address);
+  }
+})().catch(console.error);


### PR DESCRIPTION
## Summary
- Parameterized `tests/test_swap.ts` to validate the reserve symbol against all 6 registered reserves in `devnet-config.json` instead of a hardcoded 2-symbol switch, and removed the dead `remainingAccounts`/`configKeys` plumbing (verified that `sale_trade_event`/`buy_trade_event` never read `ctx.remaining_accounts`)
- Added `tests/update_reserve_lbpair.ts`, which links each registered reserve to its Meteora pool via the `update_reserve_lbpair` instruction — a hard prerequisite for the trade-event tests, since `sale_trade_event`/`buy_trade_event` silently no-op without a matching `SinglePosition`
- Ran the full mint/redeem test matrix against all 5 linkable pools (devUSDT, devPYUSD, devUSDS, devUSDG, devFDUSD) and recorded results in `TestResults.md`
- Documented the full Phase 4 process, including a concrete reproduction of the pre-existing `devUSDC` mint mis-registration bug (now surfaced via `InvalidLbPairState` when attempting to link it), in `docs/phase4-integration-testing.md`

## Test plan
- [x] `npx ts-node tests/update_reserve_lbpair.ts all` — linked 5/6 reserves on devnet (devUSDC blocked by pre-existing bug)
- [x] `npx ts-node tests/test_swap.ts mo <symbol>` and `ro <symbol>` — ran against all 5 linkable reserves, all transactions confirmed
- [x] Verified reserve totals, IRMA circulation, mint/redemption prices, and decimals all behave as expected post-run