### PR TITLE
   Fix stale Core clone causing double-deposit 

### DIFF
--- a/irma/idls/dlmm.json
+++ b/irma/idls/dlmm.json
@@ -2,7 +2,7 @@
   "address": "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo",
   "metadata": {
     "name": "lb_clmm",
-    "version": "0.11.0",
+    "version": "0.12.0",
     "spec": "0.1.0",
     "description": "Created with Anchor"
   },
@@ -4031,87 +4031,6 @@
       "args": []
     },
     {
-      "name": "migrate_position",
-      "discriminator": [
-        15,
-        132,
-        59,
-        50,
-        199,
-        6,
-        251,
-        46
-      ],
-      "accounts": [
-        {
-          "name": "position_v2",
-          "writable": true,
-          "signer": true
-        },
-        {
-          "name": "position_v1",
-          "writable": true
-        },
-        {
-          "name": "lb_pair"
-        },
-        {
-          "name": "bin_array_lower",
-          "writable": true
-        },
-        {
-          "name": "bin_array_upper",
-          "writable": true
-        },
-        {
-          "name": "signer_and_payer",
-          "writable": true,
-          "signer": true
-        },
-        {
-          "name": "system_program",
-          "address": "11111111111111111111111111111111"
-        },
-        {
-          "name": "rent_receiver",
-          "writable": true
-        },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "name": "program"
-        }
-      ],
-      "args": []
-    },
-    {
       "name": "rebalance_liquidity",
       "discriminator": [
         92,
@@ -4907,93 +4826,6 @@
       ]
     },
     {
-      "name": "reset_bin_array_tombstone_fields",
-      "discriminator": [
-        54,
-        90,
-        252,
-        63,
-        41,
-        206,
-        63,
-        63
-      ],
-      "accounts": [
-        {
-          "name": "lb_pair",
-          "relations": [
-            "bin_array"
-          ]
-        },
-        {
-          "name": "bin_array",
-          "writable": true
-        },
-        {
-          "name": "operator"
-        },
-        {
-          "name": "signer",
-          "signer": true
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "reset_pool_tombstone_fields",
-      "discriminator": [
-        246,
-        109,
-        19,
-        120,
-        108,
-        113,
-        68,
-        252
-      ],
-      "accounts": [
-        {
-          "name": "lb_pair",
-          "writable": true
-        },
-        {
-          "name": "operator"
-        },
-        {
-          "name": "signer",
-          "signer": true
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "reset_position_tombstone_fields",
-      "discriminator": [
-        206,
-        6,
-        51,
-        218,
-        211,
-        30,
-        159,
-        84
-      ],
-      "accounts": [
-        {
-          "name": "position",
-          "writable": true
-        },
-        {
-          "name": "operator"
-        },
-        {
-          "name": "signer",
-          "signer": true
-        }
-      ],
-      "args": []
-    },
-    {
       "name": "set_activation_point",
       "discriminator": [
         91,
@@ -5163,6 +4995,7 @@
         },
         {
           "name": "bin_array_bitmap_extension",
+          "writable": true,
           "optional": true
         },
         {
@@ -5289,6 +5122,7 @@
         },
         {
           "name": "bin_array_bitmap_extension",
+          "writable": true,
           "optional": true
         },
         {
@@ -5425,6 +5259,7 @@
         },
         {
           "name": "bin_array_bitmap_extension",
+          "writable": true,
           "optional": true
         },
         {
@@ -5551,6 +5386,7 @@
         },
         {
           "name": "bin_array_bitmap_extension",
+          "writable": true,
           "optional": true
         },
         {
@@ -5687,6 +5523,7 @@
         },
         {
           "name": "bin_array_bitmap_extension",
+          "writable": true,
           "optional": true
         },
         {
@@ -5819,6 +5656,7 @@
         },
         {
           "name": "bin_array_bitmap_extension",
+          "writable": true,
           "optional": true
         },
         {
@@ -6604,6 +6442,534 @@
           }
         }
       ]
+    },
+    {
+      "name": "add_liquidity_by_weight2",
+      "discriminator": [
+        209,
+        59,
+        63,
+        91,
+        111,
+        200,
+        153,
+        228
+      ],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": [
+            "lb_pair"
+          ]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": [
+            "lb_pair"
+          ]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": [
+            "lb_pair"
+          ]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": [
+            "lb_pair"
+          ]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByWeight"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "cancel_limit_order",
+      "discriminator": [
+        132,
+        156,
+        132,
+        31,
+        67,
+        40,
+        232,
+        97
+      ],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "bin_array_bitmap_extension",
+            "limit_order"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": [
+            "lb_pair"
+          ]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": [
+            "lb_pair"
+          ]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": [
+            "lb_pair"
+          ]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": [
+            "lb_pair"
+          ]
+        },
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "owner_token_x",
+          "writable": true,
+          "docs": [
+            "When dont set it tokenAccount to prevent unnecessary create token account (rent fee) when user only withdraw token y"
+          ]
+        },
+        {
+          "name": "owner_token_y",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bins",
+          "type": {
+            "vec": "i32"
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_bin_array",
+      "discriminator": [
+        68,
+        174,
+        88,
+        80,
+        181,
+        204,
+        19,
+        224
+      ],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "relations": [
+            "bin_array"
+          ]
+        },
+        {
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_limit_order_if_empty",
+      "discriminator": [
+        57,
+        124,
+        36,
+        155,
+        126,
+        249,
+        93,
+        171
+      ],
+      "accounts": [
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "place_limit_order",
+      "discriminator": [
+        108,
+        176,
+        33,
+        186,
+        146,
+        229,
+        1,
+        197
+      ],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "bin_array_bitmap_extension"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "limit_order",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "owner"
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "PlaceLimitOrderParams"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "set_permissionless_operation_bits",
+      "discriminator": [
+        84,
+        58,
+        203,
+        139,
+        163,
+        81,
+        190,
+        186
+      ],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "relations": [
+            "position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bits",
+          "type": "u8"
+        }
+      ]
     }
   ],
   "accounts": [
@@ -6699,19 +7065,6 @@
       ]
     },
     {
-      "name": "Position",
-      "discriminator": [
-        170,
-        188,
-        143,
-        228,
-        122,
-        64,
-        247,
-        208
-      ]
-    },
-    {
       "name": "PositionV2",
       "discriminator": [
         117,
@@ -6761,6 +7114,19 @@
         116,
         255,
         150
+      ]
+    },
+    {
+      "name": "LimitOrder",
+      "discriminator": [
+        137,
+        183,
+        212,
+        91,
+        115,
+        29,
+        141,
+        227
       ]
     }
   ],
@@ -7088,6 +7454,71 @@
         215,
         154,
         244
+      ]
+    },
+    {
+      "name": "CancelLimitOrderEvt",
+      "discriminator": [
+        131,
+        234,
+        194,
+        133,
+        9,
+        14,
+        189,
+        209
+      ]
+    },
+    {
+      "name": "CloseLimitOrderEvt",
+      "discriminator": [
+        142,
+        135,
+        8,
+        76,
+        92,
+        63,
+        118,
+        83
+      ]
+    },
+    {
+      "name": "PlaceLimitOrderEvt",
+      "discriminator": [
+        43,
+        79,
+        27,
+        169,
+        244,
+        28,
+        225,
+        63
+      ]
+    },
+    {
+      "name": "SetPositionPermissionlessOperationBitsEvt",
+      "discriminator": [
+        195,
+        229,
+        147,
+        245,
+        29,
+        125,
+        48,
+        168
+      ]
+    },
+    {
+      "name": "Swap2Evt",
+      "discriminator": [
+        46,
+        116,
+        82,
+        215,
+        148,
+        27,
+        84,
+        77
       ]
     }
   ],
@@ -7611,6 +8042,41 @@
       "code": 6103,
       "name": "InvalidZapOutParameters",
       "msg": "Invalid zap out parameters"
+    },
+    {
+      "code": 6104,
+      "name": "InsufficientInAmount",
+      "msg": "Insufficient in amount"
+    },
+    {
+      "code": 6105,
+      "name": "InvalidPlaceLimitOrderParameters",
+      "msg": "Invalid place limit order parameters"
+    },
+    {
+      "code": 6106,
+      "name": "InvalidLimitOrderOwner",
+      "msg": "Invalid limit order owner"
+    },
+    {
+      "code": 6107,
+      "name": "InvalidCancelLimitOrderParameters",
+      "msg": "Invalid cancel limit order parameters"
+    },
+    {
+      "code": 6108,
+      "name": "CannotFindLimitOrderByBinId",
+      "msg": "Cannot find limit order by bin id"
+    },
+    {
+      "code": 6109,
+      "name": "CancelNonEmptyLimitOrder",
+      "msg": "Cannot cancel non-empty limit order"
+    },
+    {
+      "code": 6110,
+      "name": "InvalidCollectFeeMode",
+      "msg": "Invalid collect fee mode"
     }
   ],
   "types": [
@@ -7828,14 +8294,14 @@
           {
             "name": "amount_x",
             "docs": [
-              "Amount of token X in the bin. This already excluded protocol fees."
+              "Amount of token X in the bin for market making. This already excluded protocol fees."
             ],
             "type": "u64"
           },
           {
             "name": "amount_y",
             "docs": [
-              "Amount of token Y in the bin. This already excluded protocol fees."
+              "Amount of token Y in the bin for market making. This already excluded protocol fees."
             ],
             "type": "u64"
           },
@@ -7849,21 +8315,37 @@
           {
             "name": "liquidity_supply",
             "docs": [
-              "Liquidities of the bin. This is the same as LP mint supply. q-number"
+              "Bin MM liquidity supply."
             ],
             "type": "u128"
           },
           {
-            "name": "function_bytes",
+            "name": "fulfilled_order_amount_x",
             "docs": [
-              "function bytes, could be used for liquidity mining or other functions in future"
+              "Total fulfilled order amount x"
             ],
-            "type": {
-              "array": [
-                "u128",
-                2
-              ]
-            }
+            "type": "u64"
+          },
+          {
+            "name": "fulfilled_order_amount_y",
+            "docs": [
+              "Total fulfilled order amount y"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "limit_order_fee_ask_side",
+            "docs": [
+              "Limit order fee collected by ask side orders"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "limit_order_fee_bid_side",
+            "docs": [
+              "Limit order fee collected by bid side orders"
+            ],
+            "type": "u64"
           },
           {
             "name": "fee_amount_x_per_token_stored",
@@ -7880,18 +8362,51 @@
             "type": "u128"
           },
           {
-            "name": "_padding_0",
+            "name": "open_order_amount",
             "docs": [
-              "_padding_0, previous amount_x_in, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
+              "Pending open limit orders amount in the bin."
             ],
-            "type": "u128"
+            "type": "u64"
+          },
+          {
+            "name": "total_processing_order_amount",
+            "docs": [
+              "Total processing order amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "processed_order_remaining_amount",
+            "docs": [
+              "Remaining in processing open limit orders amount in the bin."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "order_age",
+            "docs": [
+              "Age"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "limit_order_ask_side",
+            "docs": [
+              "limit order flag"
+            ],
+            "type": "u8"
           },
           {
             "name": "_padding_1",
             "docs": [
-              "_padding_1, previous amount_y_in, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
+              "padding"
             ],
-            "type": "u128"
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
           }
         ]
       }
@@ -8331,9 +8846,16 @@
             "type": "u8"
           },
           {
-            "name": "function_type",
+            "name": "concrete_function_type",
             "docs": [
-              "function type"
+              "Concrete function type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": [
+              "Collect fee mode"
             ],
             "type": "u8"
           },
@@ -8345,7 +8867,7 @@
             "type": {
               "array": [
                 "u8",
-                61
+                60
               ]
             }
           }
@@ -8710,6 +9232,14 @@
           {
             "name": "protocol_share",
             "type": "u16"
+          },
+          {
+            "name": "concrete_function_type",
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
           }
         ]
       }
@@ -8787,9 +9317,16 @@
             "type": "u8"
           },
           {
-            "name": "function_type",
+            "name": "concrete_function_type",
             "docs": [
               "function type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": [
+              "collect fee mode"
             ],
             "type": "u8"
           }
@@ -9000,7 +9537,7 @@
           {
             "name": "_padding_1",
             "docs": [
-              "_padding_1, previous Fee owner, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
+              "padding 1"
             ],
             "type": {
               "array": [
@@ -9054,7 +9591,7 @@
           {
             "name": "_padding_2",
             "docs": [
-              "_padding_2, previous whitelisted_wallet, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
+              "_padding_2"
             ],
             "type": {
               "array": [
@@ -9094,7 +9631,7 @@
           {
             "name": "_padding_3",
             "docs": [
-              "_padding 3 is reclaimed free space from swap_cap_deactivate_point and swap_cap_amount before, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
+              "_padding 3"
             ],
             "type": {
               "array": [
@@ -9106,7 +9643,7 @@
           {
             "name": "_padding_4",
             "docs": [
-              "_padding_4, previous lock_duration, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
+              "_padding_4"
             ],
             "type": "u64"
           },
@@ -9392,10 +9929,10 @@
     },
     {
       "name": "Operator",
-      "serialization": "bytemuck",
       "repr": {
         "kind": "c"
       },
+      "serialization": "bytemuck",
       "type": {
         "kind": "struct",
         "fields": [
@@ -9494,135 +10031,6 @@
           },
           {
             "name": "PermissionlessV2"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Position",
-      "serialization": "bytemuck",
-      "repr": {
-        "kind": "c"
-      },
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lb_pair",
-            "docs": [
-              "The LB pair of this position"
-            ],
-            "type": "pubkey"
-          },
-          {
-            "name": "owner",
-            "docs": [
-              "Owner of the position. Client rely on this to to fetch their positions."
-            ],
-            "type": "pubkey"
-          },
-          {
-            "name": "liquidity_shares",
-            "docs": [
-              "Liquidity shares of this position in bins (lower_bin_id <-> upper_bin_id). This is the same as LP concept."
-            ],
-            "type": {
-              "array": [
-                "u64",
-                70
-              ]
-            }
-          },
-          {
-            "name": "reward_infos",
-            "docs": [
-              "Farming reward information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": {
-                    "name": "UserRewardInfo"
-                  }
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "fee_infos",
-            "docs": [
-              "Swap fee to claim information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": {
-                    "name": "FeeInfo"
-                  }
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "lower_bin_id",
-            "docs": [
-              "Lower bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "upper_bin_id",
-            "docs": [
-              "Upper bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "last_updated_at",
-            "docs": [
-              "Last updated timestamp"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "total_claimed_fee_x_amount",
-            "docs": [
-              "Total claimed token fee X"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "total_claimed_fee_y_amount",
-            "docs": [
-              "Total claimed token fee Y"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "total_claimed_rewards",
-            "docs": [
-              "Total claimed rewards"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                2
-              ]
-            }
-          },
-          {
-            "name": "_reserved",
-            "docs": [
-              "Reserved space for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                160
-              ]
-            }
           }
         ]
       }
@@ -9845,6 +10253,10 @@
             "type": "u8"
           },
           {
+            "name": "permissionless_operation_bits",
+            "type": "u8"
+          },
+          {
             "name": "_reserved",
             "docs": [
               "Reserved space for future use"
@@ -9852,7 +10264,7 @@
             "type": {
               "array": [
                 "u8",
-                86
+                85
               ]
             }
           }
@@ -10017,11 +10429,27 @@
             "type": "u8"
           },
           {
-            "name": "function_type",
+            "name": "concrete_function_type",
             "docs": [
-              "function type, to check whether the pool should have LM farming or other functions in the future, refer FunctionType"
+              "function type, to check whether the pool should have LM farming or other functions in the future, refer ConcreteFunctionType"
             ],
             "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": [
+              "collect fee mode"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
           },
           {
             "name": "padding_1",
@@ -10031,7 +10459,7 @@
             "type": {
               "array": [
                 "u64",
-                20
+                19
               ]
             }
           }
@@ -10040,10 +10468,10 @@
     },
     {
       "name": "ProtocolFee",
-      "serialization": "bytemuck",
       "repr": {
         "kind": "c"
       },
+      "serialization": "bytemuck",
       "type": {
         "kind": "struct",
         "fields": [
@@ -10539,6 +10967,13 @@
             "type": "u8"
           },
           {
+            "name": "collect_fee_mode",
+            "docs": [
+              "Collect fee mode"
+            ],
+            "type": "u8"
+          },
+          {
             "name": "_padding",
             "docs": [
               "Padding for bytemuck safe alignment"
@@ -10546,7 +10981,7 @@
             "type": {
               "array": [
                 "u8",
-                4
+                3
               ]
             }
           }
@@ -10949,12 +11384,362 @@
           }
         ]
       }
+    },
+    {
+      "name": "BinLimitOrderAmount",
+      "type": {
+        "fields": [
+          {
+            "name": "id",
+            "type": "i32"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "CancelLimitOrderEvt",
+      "type": {
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "type": "pubkey"
+          },
+          {
+            "name": "amounts",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          },
+          {
+            "name": "active_id",
+            "type": "i32"
+          },
+          {
+            "name": "bins",
+            "type": {
+              "vec": "i32"
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "CloseLimitOrderEvt",
+      "type": {
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "type": "pubkey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LimitOrder",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "name": "lb_pair",
+            "docs": [
+              "The LB pair of this LO"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner of the LO. Client rely on this to to fetch their LOs."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_count",
+            "docs": [
+              "Bin count"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "Padding"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
+            }
+          },
+          {
+            "name": "padding_1",
+            "docs": [
+              "Reserved space for future use"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "PlaceLimitOrderEvt",
+      "type": {
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "sender",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "type": "pubkey"
+          },
+          {
+            "name": "active_id",
+            "type": "i32"
+          },
+          {
+            "name": "params",
+            "type": {
+              "defined": {
+                "name": "PlaceLimitOrderParams"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "PlaceLimitOrderParams",
+      "type": {
+        "fields": [
+          {
+            "name": "is_ask_side",
+            "type": "bool"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "relative_bin",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "RelativeBin"
+                }
+              }
+            }
+          },
+          {
+            "name": "bins",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLimitOrderAmount"
+                }
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "RelativeBin",
+      "type": {
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": [
+              "Active bin that integrator observe off-chain"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": [
+              "max active bin slippage allowed"
+            ],
+            "type": "i32"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SetPositionPermissionlessOperationBitsEvt",
+      "type": {
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "old_bits",
+            "type": "u8"
+          },
+          {
+            "name": "new_bits",
+            "type": "u8"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "Swap2Evt",
+      "type": {
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "start_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "end_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "swap_for_y",
+            "type": "bool"
+          },
+          {
+            "name": "fee_bps",
+            "type": "u128"
+          },
+          {
+            "name": "amount_in",
+            "docs": [
+              "Total amount, user transfer out"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_left",
+            "docs": [
+              "Leftover amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_out",
+            "docs": [
+              "Total amount transfer to user, including transfer fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "mm_fee",
+            "docs": [
+              "Market maker fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "docs": [
+              "Total protocol fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "limit_order_fee",
+            "docs": [
+              "Total limit order fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "host_fee",
+            "docs": [
+              "Total host fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fees_on_input",
+            "docs": [
+              "check if fees on input"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "fees_on_token_x",
+            "docs": [
+              "check if fees is on token x"
+            ],
+            "type": "bool"
+          }
+        ],
+        "kind": "struct"
+      }
     }
   ],
   "constants": [
     {
       "name": "BASIS_POINT_MAX",
-      "type": "i32",
+      "type": "u16",
       "value": "10000"
     },
     {
@@ -10986,11 +11771,6 @@
       "name": "EXTENSION_BINARRAY_BITMAP_SIZE",
       "type": "u64",
       "value": "12"
-    },
-    {
-      "name": "FEE_PRECISION",
-      "type": "u64",
-      "value": "1000000000"
     },
     {
       "name": "HOST_FEE_BPS",
@@ -11122,6 +11902,21 @@
       "name": "PROTOCOL_SHARE",
       "type": "u16",
       "value": "500"
+    },
+    {
+      "name": "FEE_DENOMINATOR",
+      "type": "u64",
+      "value": "1000000000"
+    },
+    {
+      "name": "LIMIT_ORDER_FEE_SHARE",
+      "type": "u16",
+      "value": "5000"
+    },
+    {
+      "name": "MAX_BIN_PER_LIMIT_ORDER",
+      "type": "u64",
+      "value": "50"
     }
   ]
 }

--- a/irma/programs/irma/src/lib.rs
+++ b/irma/programs/irma/src/lib.rs
@@ -559,22 +559,18 @@ pub mod irma {
             if needs_mint_shift {
                 core.shift_mint_position(
                     payer, remaining_accounts, core_mut_position, mint_price_bin_id)?;
-                // core.refresh_position_data(&creator, remaining_accounts, &mut core_position, true)?;
             }
 
             if needs_redeem_shift {
                 core.shift_redeem_position(
                     payer, remaining_accounts, core_mut_position, redemption_price_bin_id)?;
-                // core.refresh_position_data(&creator, remaining_accounts, &mut core_position, false)?;
             }
 
-            // Find the core_position index for this lb_pair
-            let pos_index = core.position_data.all_positions.iter()
-                .position(|p| p.lb_pair == lb_pair_key)
-                .ok_or(error!(CustomError::SinglePositionNotFound))?;
-
-            // check that bid and ask positions are still healthy
-            let (delta_x, delta_y) = core.check_position_health(remaining_accounts, pos_index)?;
+            // check that bid and ask positions are still healthy - read from
+            // core_mut_position (the live position, reflecting any deposits made
+            // by the shifts above), not from `core`, which is a snapshot cloned
+            // before this function ran and would otherwise show stale liquidity.
+            let (delta_x, delta_y) = core.check_position_health(remaining_accounts, core_mut_position)?;
             if delta_x > 0 {
                 msg!("Minting position for lb_pair {} is not healthy, replenishing.", lb_pair_key);
                 core.replenish_minting_position(

--- a/irma/programs/irma/src/meteora_integration.rs
+++ b/irma/programs/irma/src/meteora_integration.rs
@@ -946,15 +946,15 @@ impl Core {
 
 
     /// Check the health of a position, returning the amounts needed to replenish it.
+    /// Takes the position directly (rather than an index into `self.position_data`)
+    /// so callers can pass the live, just-mutated `SinglePosition` from the current
+    /// instruction instead of a pre-shift snapshot of `self`.
     pub fn check_position_health<'a>(
         &self,
         acct_infos: &'a [AccountInfo<'a>],
-        state_index: usize, // ;pool or lb_pair index
+        state: &SinglePosition,
     ) -> Result<(u64, u64)> {
-        let state = &self.position_data.all_positions
-            .get(state_index)
-            .ok_or(error!(CustomError::PositionNotFound))?;
-        let (mut replenish_x_amount, mut replenish_y_amount) = 
+        let (mut replenish_x_amount, mut replenish_y_amount) =
                     state.get_liquidity_in_position(acct_infos, &self.position_data)?;
         msg!("    --> amount_x remaining: {}, amount_y remaining: {}", 
                     replenish_x_amount, replenish_y_amount);


### PR DESCRIPTION
   Fix stale Core clone causing double-deposit in check_shift_price_r…anges (#112)

   check_shift_price_ranges cloned ctx.accounts.core before shift_mint_position/
   shift_redeem_position ran, then called check_position_health on that stale
   clone. Since the clone never saw the deposits the shifts had just made, the
   health check always read pre-deposit liquidity and fired a second redundant
   replenishment deposit in the same transaction.

   check_position_health now takes the live SinglePosition directly (mirroring
   how shift_mint_position/shift_redeem_position/replenish_* already receive it)
   instead of indexing into the stale clone by position index, so it sees
   deposits made earlier in the same instruction.

   Verified on a local validator: the unfixed build deposited 1,100,000 IRMA
   twice in one transaction; the fixed build deposits it once.