### PR TITLE
Fix out-of-bounds panic in position_manager 

### DIFF
--- a/irma/programs/irma/src/position_manager.rs
+++ b/irma/programs/irma/src/position_manager.rs
@@ -195,7 +195,7 @@ impl SinglePosition {
         if positions.len() == 0 || positions.len() > MAX_POSITIONS {
             return Ok(PositionRaw::default());
         }
-        if positions[0].lower_bin_id == positions[1].lower_bin_id {
+        if positions.len() > 1 && positions[0].lower_bin_id == positions[1].lower_bin_id {
             positions.remove(1);
         }
         
@@ -207,7 +207,7 @@ impl SinglePosition {
         if bin_arrays.len() == 0 || bin_arrays.len() > MAX_POSITIONS {
             Err(Error::from(CustomError::FailedToFetchBinArrays))?;
         }
-        if bin_arrays[0].0 == bin_arrays[1].0 {
+        if bin_arrays.len() > 1 && bin_arrays[0].0 == bin_arrays[1].0 {
             bin_arrays.remove(1);
         }
 

--- a/irma/programs/irma/tests/meteora_integration.rs
+++ b/irma/programs/irma/tests/meteora_integration.rs
@@ -91,7 +91,8 @@ mod core_test {
             _padding_0: 0u8,
             fee_owner: Pubkey::new_unique(),
             version: 0u8,
-            _reserved: [0u8; 86],
+            permissionless_operation_bits: 0u8,
+            _reserved: [0u8; 85],
         }
     }
 


### PR DESCRIPTION
when only one position exists

Guard positions[1] and bin_arrays[1] accesses with len > 1 checks so check_shift_price_ranges does not panic on a fresh pool that has only a mint position and no redemption position yet.