### PR TITLE
Fix remove_reserve overflow and V1 position fallback in replenish

### DIFF
--- a/irma/programs/irma/src/meteora_integration.rs
+++ b/irma/programs/irma/src/meteora_integration.rs
@@ -984,8 +984,11 @@ impl Core {
         mut_state: &mut SinglePosition, // modify only position_pks, bin_array_pks
         amount_x: u64,
     ) -> Result<()> {
-        if mut_state.position_pks[0] == Pubkey::default() {
-            // initialize a new position and add to position_pks
+        // Treat a missing or unfindable position (e.g. a stale V1 keypair position
+        // that predates V2 PDAs) the same as an uninitialized key: create a fresh V2 PDA.
+        let needs_init = mut_state.position_pks[0] == Pubkey::default()
+            || fetch_positions(remaining_accounts_in, &[mut_state.position_pks[0]])?.is_empty();
+        if needs_init {
             let new_position_key = self.initialize_position(
                 payer,
                 remaining_accounts_in,
@@ -1010,8 +1013,9 @@ impl Core {
         mut_state: &mut SinglePosition, // modify only position_pks, bin_array_pks
         amount_y: u64,
     ) -> Result<()> {
-        if mut_state.position_pks[1] == Pubkey::default() {
-            // initialize a new position and add to position_pks
+        let needs_init = mut_state.position_pks[1] == Pubkey::default()
+            || fetch_positions(remaining_accounts_in, &[mut_state.position_pks[1]])?.is_empty();
+        if needs_init {
             let new_position_key = self.initialize_position(
                 payer,
                 remaining_accounts_in,

--- a/irma/programs/irma/src/meteora_integration.rs
+++ b/irma/programs/irma/src/meteora_integration.rs
@@ -984,6 +984,10 @@ impl Core {
         mut_state: &mut SinglePosition, // modify only position_pks, bin_array_pks
         amount_x: u64,
     ) -> Result<()> {
+        // Ensure position_pks always has 2 initialized slots (legacy on-chain state may be empty).
+        while mut_state.position_pks.len() < 2 {
+            mut_state.position_pks.push(Pubkey::default());
+        }
         // Treat a missing or unfindable position (e.g. a stale V1 keypair position
         // that predates V2 PDAs) the same as an uninitialized key: create a fresh V2 PDA.
         let needs_init = mut_state.position_pks[0] == Pubkey::default()
@@ -1013,6 +1017,10 @@ impl Core {
         mut_state: &mut SinglePosition, // modify only position_pks, bin_array_pks
         amount_y: u64,
     ) -> Result<()> {
+        // Ensure position_pks always has 2 initialized slots (legacy on-chain state may be empty).
+        while mut_state.position_pks.len() < 2 {
+            mut_state.position_pks.push(Pubkey::default());
+        }
         let needs_init = mut_state.position_pks[1] == Pubkey::default()
             || fetch_positions(remaining_accounts_in, &[mut_state.position_pks[1]])?.is_empty();
         if needs_init {
@@ -1585,6 +1593,11 @@ impl Core {
         ).or_else(|error| Err(error)).unwrap();
         msg!("==> Fetched {} matching positions", position_keys_with_states.len());
 
+        // Ensure position_pks always has 2 initialized slots (legacy on-chain state may be empty).
+        while mut_state.position_pks.len() < 2 {
+            mut_state.position_pks.push(Pubkey::default());
+        }
+
         let new_position =
         if mut_state.position_pks[0] != Pubkey::default() {
             let poskey = mut_state.position_pks[0];
@@ -1666,6 +1679,11 @@ impl Core {
             &pair_address
         ).or_else(|error| Err(error)).unwrap();
         msg!("==> Redeem: Fetched {} matching positions", position_keys_with_states.len());
+
+        // Ensure position_pks always has 2 initialized slots (legacy on-chain state may be empty).
+        while mut_state.position_pks.len() < 2 {
+            mut_state.position_pks.push(Pubkey::default());
+        }
 
         let new_position =
         if mut_state.position_pks[1] != Pubkey::default() {

--- a/irma/programs/irma/src/pricing.rs
+++ b/irma/programs/irma/src/pricing.rs
@@ -372,8 +372,10 @@ impl StateMap {
             msg!("Stablecoin {} not found in reserves.", symbol);
             return None;
         }
-        let i = self.reserves.partition_point(|e| e.symbol > symbol.to_string());
-        Some(self.reserves.remove(i - 1))
+        // reserves is sorted ascending by symbol (add_reserve uses partition_point with `< symbol`);
+        // so partition_point with `< symbol` gives the index of this exact element.
+        let i = self.reserves.partition_point(|e| e.symbol.as_str() < symbol);
+        Some(self.reserves.remove(i))
     }
 
     pub fn disable_reserve(&mut self, symbol: &str) {

--- a/irma/scripts/devnet_check_shift.cjs
+++ b/irma/scripts/devnet_check_shift.cjs
@@ -1,0 +1,230 @@
+// Trigger checkShiftPriceRanges on devnet for a specific pool.
+//
+// Forces a mint-price shift so shift_mint_position() runs, which:
+//   - Calls withdraw() on whatever position_pks[0] currently is
+//   - If not found (e.g. stale V1 key), auto-creates a fresh V2 PDA
+//   - Sets position_pks[0] to the new V2 PDA
+//   - Deposits IRMA into it
+//
+// This is the workaround for the V1-position issue where seed_dlmm_liquidity.cjs
+// created a legacy V1 keypair position that the program can no longer use.
+//
+// Usage: node scripts/devnet_check_shift.cjs <symbol>
+//   e.g. node scripts/devnet_check_shift.cjs usdt
+"use strict";
+
+const {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  ComputeBudgetProgram,
+  SYSVAR_RENT_PUBKEY,
+  SYSVAR_CLOCK_PUBKEY,
+  sendAndConfirmTransaction,
+} = require("@solana/web3.js");
+const { AnchorProvider, Program } = require("@coral-xyz/anchor");
+const {
+  getAssociatedTokenAddressSync,
+  TOKEN_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
+} = require("@solana/spl-token");
+const DLMM = require("@meteora-ag/dlmm");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+require("dotenv").config({ path: path.join(__dirname, "../.env") });
+
+const config = JSON.parse(fs.readFileSync(path.join(__dirname, "../devnet-config.json"), "utf-8"));
+const idl = JSON.parse(fs.readFileSync(path.join(__dirname, "../target/idl/irma.json"), "utf-8"));
+
+const REAL_PROGRAM_ID = new PublicKey("E15v5VirGqdbH4fYhxxxZHNiLAP3t3y1SPonhrQxoTcs");
+const DLMM_PROGRAM_ID = new PublicKey("LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo");
+const MEMO_PROGRAM = new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
+
+const i32le = (n) => { const b = Buffer.alloc(4); b.writeInt32LE(n, 0); return b; };
+const i64le = (n) => { const b = Buffer.alloc(8); b.writeBigInt64LE(BigInt(n), 0); return b; };
+const BIN_ARRAY_SIZE = 70;
+
+async function buildRemainingAccounts(dlmmPool, adminKeypair, irmaMint, reserveMint) {
+  const [{ userPositions }, binArraysX2Y, binArraysY2X] = await Promise.all([
+    dlmmPool.getPositionsByUserAndLbPair(adminKeypair.publicKey),
+    dlmmPool.getBinArrayForSwap(false),
+    dlmmPool.getBinArrayForSwap(true),
+  ]);
+
+  const binArrayKeySet = new Set([
+    ...binArraysX2Y.map((b) => b.publicKey.toBase58()),
+    ...binArraysY2X.map((b) => b.publicKey.toBase58()),
+  ]);
+
+  const nearbyIndices = new Set([-1, 0, 1]);
+  for (const p of userPositions) {
+    if (p?.positionData?.lowerBinId === undefined) continue;
+    const idx = Math.floor(p.positionData.lowerBinId / BIN_ARRAY_SIZE);
+    for (const d of [-1, 0, 1]) nearbyIndices.add(idx + d);
+  }
+
+  const derivedMetas = [...nearbyIndices].flatMap((idx) => {
+    const lowerBinId = idx * BIN_ARRAY_SIZE;
+    const [positionPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("position"), dlmmPool.pubkey.toBuffer(), adminKeypair.publicKey.toBuffer(), i32le(lowerBinId), i32le(BIN_ARRAY_SIZE)],
+      DLMM_PROGRAM_ID
+    );
+    const [binArrayPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("bin_array"), dlmmPool.pubkey.toBuffer(), i64le(idx)],
+      DLMM_PROGRAM_ID
+    );
+    return [
+      { pubkey: positionPda, isSigner: false, isWritable: true },
+      { pubkey: binArrayPda, isSigner: false, isWritable: true },
+    ];
+  });
+
+  const adminIrmaAta = getAssociatedTokenAddressSync(irmaMint, adminKeypair.publicKey, false, TOKEN_2022_PROGRAM_ID);
+  const adminReserveAta = getAssociatedTokenAddressSync(reserveMint, adminKeypair.publicKey, false, TOKEN_PROGRAM_ID);
+
+  const entries = [
+    { pubkey: dlmmPool.pubkey, isSigner: false, isWritable: true },
+    ...derivedMetas,
+    ...userPositions.map((p) => ({ pubkey: p.publicKey, isSigner: false, isWritable: true })),
+    ...[...binArrayKeySet].map((k) => ({ pubkey: new PublicKey(k), isSigner: false, isWritable: true })),
+    { pubkey: irmaMint, isSigner: false, isWritable: false },
+    { pubkey: reserveMint, isSigner: false, isWritable: false },
+    { pubkey: adminIrmaAta, isSigner: false, isWritable: true },
+    { pubkey: adminReserveAta, isSigner: false, isWritable: true },
+    { pubkey: dlmmPool.tokenX.reserve, isSigner: false, isWritable: true },
+    { pubkey: dlmmPool.tokenY.reserve, isSigner: false, isWritable: true },
+    { pubkey: dlmmPool.tokenX.owner, isSigner: false, isWritable: false },
+    { pubkey: dlmmPool.lbPair.oracle, isSigner: false, isWritable: true },
+    { pubkey: adminKeypair.publicKey, isSigner: true, isWritable: true },
+    { pubkey: PublicKey.findProgramAddressSync([Buffer.from("__event_authority")], DLMM_PROGRAM_ID)[0], isSigner: false, isWritable: false },
+    ...(dlmmPool.tokenX.transferHookAccountMetas || []),
+    { pubkey: DLMM_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: TOKEN_2022_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
+    { pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false },
+    { pubkey: MEMO_PROGRAM, isSigner: false, isWritable: false },
+  ];
+
+  const seen = new Set();
+  return entries.filter(({ pubkey }) => {
+    const key = pubkey.toBase58();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+async function main() {
+  const symbol = process.argv[2];
+  if (!symbol) {
+    console.error("Usage: node scripts/devnet_check_shift.cjs <symbol>  (e.g. usdt)");
+    process.exit(1);
+  }
+
+  const poolCfg = config.pools?.[symbol];
+  const tokenCfg = config.tokens[symbol];
+  if (!poolCfg || !tokenCfg) {
+    console.error(`Unknown symbol: ${symbol}`);
+    process.exit(1);
+  }
+
+  const rpcUrl = process.env.ANCHOR_PROVIDER_URL || "https://api.devnet.solana.com";
+  const connection = new Connection(rpcUrl, "confirmed");
+
+  const keypairPath = process.env.SOLANA_KEYPAIR_PATH || path.join(os.homedir(), ".config/solana/phantom1.json");
+  const admin = Keypair.fromSecretKey(new Uint8Array(JSON.parse(fs.readFileSync(keypairPath, "utf-8"))));
+  console.log("Admin:", admin.publicKey.toBase58());
+
+  class CustomWallet {
+    constructor(kp) { this.payer = kp; }
+    async signTransaction(tx) { tx.partialSign(this.payer); return tx; }
+    async signAllTransactions(txs) { return txs.map((t) => { t.partialSign(this.payer); return t; }); }
+    get publicKey() { return this.payer.publicKey; }
+  }
+
+  const provider = new AnchorProvider(connection, new CustomWallet(admin), { commitment: "confirmed" });
+  const program = new Program(idl, provider);
+
+  const [statePda] = PublicKey.findProgramAddressSync([Buffer.from("state_v5")], REAL_PROGRAM_ID);
+  const [corePda]  = PublicKey.findProgramAddressSync([Buffer.from("core_v5")],  REAL_PROGRAM_ID);
+
+  const irmaMint   = new PublicKey(config.tokens.irma.mint);
+  const reserveMint = new PublicKey(tokenCfg.mint);
+  const poolAddress = new PublicKey(poolCfg.address);
+  const reserveSymbol = tokenCfg.name; // e.g. "devUSDT"
+
+  // --- 1. Force a price shift by setting mint price to a value in a different bin ---
+  // Current max_bin_id = 2 (price ≈ 1.001). Bump to 1.011 (~bin 22) so shift_mint_position runs.
+  // After the fix succeeds, set it back to a reasonable oracle-derived value.
+  const stateAcct = await program.account.stateMap.fetch(statePda);
+  const reserve = stateAcct.reserves.find((r) => r.symbol === reserveSymbol);
+  if (!reserve) {
+    console.error(`Reserve ${reserveSymbol} not found in StateMap.`);
+    process.exit(1);
+  }
+  const currentPrice = reserve.mintPrice;
+  console.log(`\nCurrent ${reserveSymbol} mintPrice: ${currentPrice}`);
+
+  // Alternate between 1.011 and 1.002 to always force a shift
+  const newPrice = Math.abs(currentPrice - 1.011) < 1e-9 ? 1.002 : 1.011;
+  console.log(`Setting mintPrice to ${newPrice} to force needs_mint_shift=true...`);
+  await program.methods
+    .setMintPrice(reserveSymbol, newPrice)
+    .accounts({ state: statePda, irmaAdmin: admin.publicKey, core: corePda, systemProgram: SystemProgram.programId })
+    .rpc();
+  console.log("  ✅ Price set.");
+
+  // --- 2. Build remaining accounts and call checkShiftPriceRanges ---
+  console.log(`\nLoading DLMM pool ${poolAddress.toBase58()}...`);
+  const dlmmPool = await DLMM.create(connection, poolAddress, { cluster: "devnet" });
+  const remainingAccounts = await buildRemainingAccounts(dlmmPool, admin, irmaMint, reserveMint);
+  console.log(`Built ${remainingAccounts.length} remaining accounts.`);
+
+  console.log("\nCalling checkShiftPriceRanges...");
+  const tx = await program.methods
+    .checkShiftPriceRanges(reserveSymbol)
+    .accounts({ state: statePda, irmaAdmin: admin.publicKey, core: corePda, systemProgram: SystemProgram.programId })
+    .remainingAccounts(remainingAccounts)
+    .transaction();
+
+  tx.instructions.unshift(
+    ComputeBudgetProgram.setComputeUnitLimit({ units: 1_000_000 }),
+    ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1 })
+  );
+
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
+  tx.recentBlockhash = blockhash;
+  tx.feePayer = admin.publicKey;
+  tx.sign(admin);
+
+  let signature;
+  try {
+    signature = await connection.sendRawTransaction(tx.serialize(), { skipPreflight: false });
+    console.log("  Sent:", signature);
+    await connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, "confirmed");
+    console.log("  ✅ Transaction confirmed:", signature);
+  } catch (err) {
+    console.error("  ❌ Transaction failed:", err.message);
+    if (err.logs) for (const l of err.logs) console.log(" ", l);
+  }
+
+  if (signature) {
+    const txInfo = await connection.getTransaction(signature, { commitment: "confirmed", maxSupportedTransactionVersion: 0 });
+    const logs = txInfo?.meta?.logMessages || [];
+    console.log("\n--- Transaction logs ---");
+    for (const l of logs) console.log(" ", l);
+
+    const ok = logs.some((l) => l.includes("check_shift_price_ranges called") || l.includes("Depositing liquidity"));
+    console.log(ok ? "\n✅ checkShiftPriceRanges succeeded!" : "\n⚠️  No success marker in logs — check above for errors.");
+  }
+}
+
+main().catch((err) => {
+  console.error("\n❌ Fatal:", err);
+  process.exit(1);
+});

--- a/irma/scripts/devnet_check_shift.cjs
+++ b/irma/scripts/devnet_check_shift.cjs
@@ -21,7 +21,6 @@ const {
   ComputeBudgetProgram,
   SYSVAR_RENT_PUBKEY,
   SYSVAR_CLOCK_PUBKEY,
-  sendAndConfirmTransaction,
 } = require("@solana/web3.js");
 const { AnchorProvider, Program } = require("@coral-xyz/anchor");
 const {

--- a/irma/tests/read_core_positions.ts
+++ b/irma/tests/read_core_positions.ts
@@ -1,0 +1,46 @@
+import { AnchorProvider, Program, Wallet } from "@coral-xyz/anchor";
+import { Connection, PublicKey, Keypair } from "@solana/web3.js";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import * as os from "os";
+import dotenv from "dotenv";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenv.config({ path: path.join(__dirname, "../.env") });
+
+const idl = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "../target/idl/irma.json"), "utf-8")
+);
+const PROGRAM_ID = new PublicKey(idl.address);
+
+async function main() {
+  const rpcUrl =
+    process.env.ANCHOR_PROVIDER_URL ||
+    process.env.SOLANA_RPC_URL ||
+    "https://api.devnet.solana.com";
+  const connection = new Connection(rpcUrl, "confirmed");
+  const keypair = Keypair.fromSecretKey(
+    new Uint8Array(
+      JSON.parse(
+        fs.readFileSync(path.join(os.homedir(), ".config/solana/phantom1.json"), "utf-8")
+      )
+    )
+  );
+  const wallet = new Wallet(keypair);
+  const provider = new AnchorProvider(connection, wallet, { commitment: "confirmed" });
+  const program = new Program(idl, provider);
+
+  const [corePda] = PublicKey.findProgramAddressSync([Buffer.from("core_v5")], PROGRAM_ID);
+  const core: any = await (program.account as any).core.fetch(corePda);
+
+  for (const pos of core.positionData.allPositions) {
+    const lbPair = pos.lbPair.toBase58();
+    console.log(`\nlbPair: ${lbPair}`);
+    console.log("minBinId:", pos.minBinId, "maxBinId:", pos.maxBinId);
+    console.log("positionPks:", pos.positionPks.map((p: PublicKey) => p.toBase58()));
+    console.log("binArrayPks:", pos.binArrayPks?.map((p: PublicKey) => p.toBase58()));
+  }
+}
+main().catch(console.error);


### PR DESCRIPTION
## Summary

- **`pricing.rs`**: `remove_reserve` used `partition_point(|e| e.symbol > target)` on an ascending-sorted vec. For the lexicographically largest symbol (currently `devUSDT`) the predicate is false for all elements, so `partition_point` returns 0 and `i - 1` underflows with a panic. Fixed by using the same ascending predicate (`< symbol`) already used in `add_reserve` / `get_stablecoin`, removing at index `i` directly.

- **`meteora_integration.rs`**: `replenish_minting_position` and `replenish_redeeming_position` only guarded against `Pubkey::default`. A stale V1 keypair position stored in `position_pks` would pass that guard but fail `fetch_positions` (V2-discriminator filter), causing `PositionNotFound (0x1777)`. Fixed by calling `fetch_positions` first and treating a key that returns empty the same as `Pubkey::default` — initialise a fresh V2 PDA instead.

## Root cause

`seed_dlmm_liquidity.cjs` was originally written with `Keypair.generate()` + `initializePositionAndAddLiquidityByStrategy`, which creates legacy V1 positions. The IRMA on-chain program and Meteora SDK (`getPositionsByUserAndLbPair`) are V2-only, so the stored key became unreachable once it entered `position_pks[0]`.

## Devnet workaround already applied

`scripts/devnet_check_shift.cjs` forces `mint_price_bin_id != max_bin_id` so `shift_mint_position` runs, which already has the correct V1-fallback logic (via `withdraw()` returning `false`). Running this for the USDT pool has migrated the on-chain state to a valid V2 PDA. The Rust fix closes the gap so the same scenario can't recur through the `replenish_*` path.

## Test plan

- [x] `anchor build` passes (no new warnings beyond existing unused-import)
- [ ] Carlos deploys updated program to devnet
- [x] `node scripts/devnet_check_shift.cjs usdt` confirms single deposit, no `PositionNotFound`
- [x] End-to-end swap webhook test passes for all 6 pools